### PR TITLE
Support member type qualified with namespace

### DIFF
--- a/examples/4_composition/helper.kiste
+++ b/examples/4_composition/helper.kiste
@@ -26,6 +26,8 @@
 
 %namespace test
 %{
+%namespace widgets
+%{
   $class Helper
   %auto getAnswer() -> int
   %{
@@ -38,4 +40,5 @@
   %}
 
   $endclass
+%}
 %}

--- a/examples/4_composition/sample.kiste
+++ b/examples/4_composition/sample.kiste
@@ -30,7 +30,7 @@
 %namespace test
 %{
   $class Sample
-  $member Helper helper
+  $member widgets::Helper helper
 
   %auto getName() -> std::string
   %{

--- a/src/ClassTemplate.kiste
+++ b/src/ClassTemplate.kiste
@@ -73,8 +73,15 @@
     %template<typename ClassData, typename Member>
     %void render_member(const size_t line_no, const ClassData& class_data, const Member& member)
     %{
-      %// The "using" is required for clang-3.1 and older g++ versions
-      %auto class_alias = member.class_name + "_t_alias";
+      %// The "using" is required for clang-3.1 and older g++ versions.
+      %// Replace any namespace qualification by underscores for use in the alias type name.
+      %auto unqualified_class_name = member.class_name;
+      %{
+        %size_t ns_pos;
+        %while ((ns_pos = unqualified_class_name.find("::")) != std::string::npos)
+          %unqualified_class_name.replace(ns_pos, 2, "_");
+      %}
+      %auto class_alias = unqualified_class_name + "_t_alias";
       $|using ${class_alias} = ${member.class_name}_t<${class_data._name}_t, _data_t, _serializer_t>;$|
       $|${class_alias} ${member.name} = ${class_alias}{*this, data, _serialize};
       $|$call{line_directive(line_no + 1)}


### PR DESCRIPTION
See modified example. This strips away `the::name::space::` prefix from member type string before inserting into the alias type name. Before, it was inserted directly which led to errors like

```
error: name defined in alias declaration must be an identifier
  using Widgets::Table_t_alias = Widgets::Table_t<Show_t, _data_t, _serializer_t>; Widgets::Table_t_alias table = Widgets::Table_t_alias{*this, data, _serialize};
```

since it creates invalid syntax like `using Widgets::Table_t_alias = /* ... */`.
