### PR TITLE
Use Python executable found by CMake

### DIFF
--- a/tests/template-output/CMakeLists.txt
+++ b/tests/template-output/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach(TemplateOutputTestInput ${TemplateOutputTestInputs})
   add_test(
     NAME "TemplateOutputTest_${filename_we}"
     COMMAND
-      python -B
+      ${PYTHON_EXECUTABLE} -B
       "${CMAKE_CURRENT_SOURCE_DIR}/../differ.py"
       "${TemplateOutputTestInput}"
       "${output}"


### PR DESCRIPTION
Right now I have this as local patch for 0.17 for the to-be-submitted FreeBSD port. A `python` executable is not available there, so just do what makes sense ;)